### PR TITLE
Remove second redundant Read() from rand source

### DIFF
--- a/hdkeygen/main.go
+++ b/hdkeygen/main.go
@@ -73,7 +73,6 @@ func main() {
 		if err != nil {
 			fatal("Error while reading randomness: %s\n", err)
 		}
-		r.Read(otherRand)
 
 		// Hash first the otherRand data then the users input
 		h := sha512.New()


### PR DESCRIPTION
random source is read twice onto `otherRand` (first time with `io.ReadFull` right above).